### PR TITLE
Fix invalid printer handling

### DIFF
--- a/UI/main.py
+++ b/UI/main.py
@@ -384,10 +384,17 @@ class MainWindow(QMainWindow):
 
         if config.get('printer', '') == '':
             self.ui.label_error_printer.setText("Принтер не указан")
-        elif  status_printer():
-            self.ui.label_error_printer.setText("Принтер отключен")
         else:
-            self.ui.label_error_printer.setText("")
+            status = status_printer()
+            if status is None:
+                config['printer'] = ''
+                save_config(config)
+                self.populate_printer_list()
+                self.ui.label_error_printer.setText("Принтер не найден")
+            elif status:
+                self.ui.label_error_printer.setText("Принтер отключен")
+            else:
+                self.ui.label_error_printer.setText("")
 
         if not cooridname:
             self.ui.label_error_show.setText("Область отслеживания не добавлена")

--- a/print_text.py
+++ b/print_text.py
@@ -1,10 +1,18 @@
 import win32print
 import win32ui
+import pywintypes
 from config import load_config, FONT
 
 
 def status_printer():
-    handle = win32print.OpenPrinter(load_config()['printer'])
+    """Return True if printer is offline, False if ready,
+    or None if printer name is invalid."""
+    try:
+        handle = win32print.OpenPrinter(load_config()['printer'])
+    except pywintypes.error as e:
+        if e.winerror == 1801:  # printer not found
+            return None
+        raise
     info = win32print.GetPrinter(handle, 2)
     attrs = info['Attributes']
 


### PR DESCRIPTION
## Summary
- avoid crashing if configured printer does not exist
- show appropriate message and clear printer setting

## Testing
- `python -m py_compile print_text.py UI/main.py main.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed07232f0832b88d967b1333bba64